### PR TITLE
refactor(terraform): extract diagnostics and alerts into module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ hs_err_pid14848.log
 secrets.yaml
 /terraform/.terraform
 terraform/dev.local.auto.tfvars
+terraform/errored.tfstate

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -71,64 +71,13 @@ module "container_app" {
   depends_on = [module.key_vault, module.postgres]
 }
 
-resource "azurerm_monitor_action_group" "main" {
-  count               = var.alert_email != "" ? 1 : 0
-  name                = "ag-kanban-${var.env}"
-  resource_group_name = azurerm_resource_group.main.name
-  short_name          = "kanban${var.env}"
+module "diagnostics" {
+  source = "./modules/diagnostics"
 
-  email_receiver {
-    name          = "primary"
-    email_address = var.alert_email
-  }
-}
-
-resource "azurerm_monitor_metric_alert" "container_app_high_cpu" {
-  count               = var.alert_email != "" ? 1 : 0
-  name                = "kanban-${var.env}-high-cpu"
-  resource_group_name = azurerm_resource_group.main.name
-  scopes              = [module.container_app.container_app_id]
-  description         = "Average CPU usage is close to the configured limit."
-  severity            = 2
-  enabled             = true
-
-  frequency   = "PT1M"
-  window_size = "PT5M"
-
-  criteria {
-    metric_namespace = "Microsoft.App/containerApps"
-    metric_name      = "UsageNanoCores"
-    aggregation      = "Average"
-    operator         = "GreaterThan"
-    threshold        = 200000000
-  }
-
-  action {
-    action_group_id = azurerm_monitor_action_group.main[0].id
-  }
-}
-
-resource "azurerm_monitor_metric_alert" "container_app_high_memory" {
-  count               = var.alert_email != "" ? 1 : 0
-  name                = "kanban-${var.env}-high-memory"
-  resource_group_name = azurerm_resource_group.main.name
-  scopes              = [module.container_app.container_app_id]
-  description         = "Average memory working set is close to the configured limit."
-  severity            = 2
-  enabled             = true
-
-  frequency   = "PT1M"
-  window_size = "PT5M"
-
-  criteria {
-    metric_namespace = "Microsoft.App/containerApps"
-    metric_name      = "WorkingSetBytes"
-    aggregation      = "Average"
-    operator         = "GreaterThan"
-    threshold        = 450000000
-  }
-
-  action {
-    action_group_id = azurerm_monitor_action_group.main[0].id
-  }
+  env                        = var.env
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  container_app_id           = module.container_app.container_app_id
+  container_app_env_id       = module.vnet.container_app_env_id
+  resource_group_name        = azurerm_resource_group.main.name
+  alert_email                = var.alert_email
 }

--- a/terraform/modules/diagnostics/main.tf
+++ b/terraform/modules/diagnostics/main.tf
@@ -1,0 +1,119 @@
+data "azurerm_monitor_diagnostic_categories" "container_app" {
+  resource_id = var.container_app_id
+}
+
+locals {
+  container_app_log_categories    = toset(data.azurerm_monitor_diagnostic_categories.container_app.log_category_types)
+  container_app_metric_categories = toset(try(data.azurerm_monitor_diagnostic_categories.container_app.metrics, []))
+}
+
+resource "azurerm_monitor_diagnostic_setting" "container_app" {
+  name                       = "diag-kanban-app-${var.env}"
+  target_resource_id         = var.container_app_id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  dynamic "enabled_log" {
+    for_each = local.container_app_log_categories
+    content {
+      category = enabled_log.value
+    }
+  }
+
+  dynamic "enabled_metric" {
+    for_each = local.container_app_metric_categories
+    content {
+      category = enabled_metric.value
+    }
+  }
+}
+
+data "azurerm_monitor_diagnostic_categories" "container_app_env" {
+  resource_id = var.container_app_env_id
+}
+
+locals {
+  container_app_env_log_categories    = toset(data.azurerm_monitor_diagnostic_categories.container_app_env.log_category_types)
+  container_app_env_metric_categories = toset(try(data.azurerm_monitor_diagnostic_categories.container_app_env.metrics, []))
+}
+
+resource "azurerm_monitor_diagnostic_setting" "container_app_env" {
+  name                       = "diag-kanban-cae-${var.env}"
+  target_resource_id         = var.container_app_env_id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  dynamic "enabled_log" {
+    for_each = local.container_app_env_log_categories
+    content {
+      category = enabled_log.value
+    }
+  }
+
+  dynamic "enabled_metric" {
+    for_each = local.container_app_env_metric_categories
+    content {
+      category = enabled_metric.value
+    }
+  }
+}
+
+resource "azurerm_monitor_action_group" "main" {
+  count               = var.alert_email != "" ? 1 : 0
+  name                = "ag-kanban-${var.env}"
+  resource_group_name = var.resource_group_name
+  short_name          = "kanban${var.env}"
+
+  email_receiver {
+    name          = "primary"
+    email_address = var.alert_email
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "container_app_high_cpu" {
+  count               = var.alert_email != "" ? 1 : 0
+  name                = "kanban-${var.env}-high-cpu"
+  resource_group_name = var.resource_group_name
+  scopes              = [var.container_app_id]
+  description         = "Average CPU usage is close to the configured limit."
+  severity            = 2
+  enabled             = true
+
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  criteria {
+    metric_namespace = "Microsoft.App/containerApps"
+    metric_name      = "UsageNanoCores"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 200000000
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "container_app_high_memory" {
+  count               = var.alert_email != "" ? 1 : 0
+  name                = "kanban-${var.env}-high-memory"
+  resource_group_name = var.resource_group_name
+  scopes              = [var.container_app_id]
+  description         = "Average memory working set is close to the configured limit."
+  severity            = 2
+  enabled             = true
+
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  criteria {
+    metric_namespace = "Microsoft.App/containerApps"
+    metric_name      = "WorkingSetBytes"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 450000000
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+}

--- a/terraform/modules/diagnostics/outputs.tf
+++ b/terraform/modules/diagnostics/outputs.tf
@@ -1,0 +1,9 @@
+output "container_app_diagnostic_setting_id" {
+  description = "ID of the diagnostic setting on the Container App."
+  value       = azurerm_monitor_diagnostic_setting.container_app.id
+}
+
+output "container_app_env_diagnostic_setting_id" {
+  description = "ID of the diagnostic setting on the Container Apps Environment."
+  value       = azurerm_monitor_diagnostic_setting.container_app_env.id
+}

--- a/terraform/modules/diagnostics/variables.tf
+++ b/terraform/modules/diagnostics/variables.tf
@@ -1,0 +1,29 @@
+variable "env" {
+  type        = string
+  description = "Environment name used for naming."
+}
+
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "Log Analytics Workspace resource ID."
+}
+
+variable "container_app_id" {
+  type        = string
+  description = "Resource ID of the Azure Container App."
+}
+
+variable "container_app_env_id" {
+  type        = string
+  description = "Resource ID of the Azure Container Apps Environment."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group name for alert resources."
+}
+
+variable "alert_email" {
+  type        = string
+  description = "Email address for alert notifications. Leave empty to disable alert resources."
+}


### PR DESCRIPTION
Move Container App alerting (action group + CPU/memory metric alerts) out of the root config into a dedicated diagnostics module.

Add diagnostic settings for the Container App and the Container Apps Environment, sending logs/metrics to Log Analytics.

Keep alert resources optional (gated by alert_email), preserving current behavior when no email is set.

Minor: provider formatting tidy-up (no functional change).